### PR TITLE
Update Sentry SDK to include debug log as breadcrumbs.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests
-sentry-sdk==0.6.9
+sentry-sdk
 logdna
 logzio-python-handler
 typing

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     ],
     install_requires=[
         "requests",
-        "sentry_sdk==0.6.9",
+        "sentry_sdk",
         "logzio-python-handler",
         "logdna",
         "typing",

--- a/telemetry_1a23/__init__.py
+++ b/telemetry_1a23/__init__.py
@@ -38,7 +38,7 @@ class SentryErrorReporting(TelemetryProvider):
         token = options.pop('token')
         integrations = []
         if not options.get('capture_logs'):
-            integrations.append(LoggingIntegration(level=logging.ERROR))
+            integrations.append(LoggingIntegration(level=logging.debug, event_level=logging.ERROR))
         if 'capture_logs' in options:
             del options['capture_logs']
         if 'ignored_loggers' in options:


### PR DESCRIPTION
Update Sentry SDK to include debug log as breadcrumbs. This is to bring more contexts to the error message uploaded to sentry.